### PR TITLE
Extracted  Validation logic out of Attribute implementation into general purpose Validator Assembly

### DIFF
--- a/Mariuzzo.DO.DataAnnotations.sln
+++ b/Mariuzzo.DO.DataAnnotations.sln
@@ -1,6 +1,6 @@
 ﻿
-Microsoft Visual Studio Solution File, Format Version 11.00
-# Visual Studio 2010
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mariuzzo.DO.DataAnnotations", "Mariuzzo.DO.DataAnnotations\Mariuzzo.DO.DataAnnotations.csproj", "{EA62A23F-540A-4A08-BF65-2B0E7D9571E6}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mariuzzo.DO.DataAnnotations.Test", "Mariuzzo.Do.DataAnnotations.Test\Mariuzzo.DO.DataAnnotations.Test.csproj", "{94A1DB79-EDF1-4A8E-90F1-CAD0BDB30E03}"
@@ -11,6 +11,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		Mariuzzo.DO.DataAnnotations.vsmdi = Mariuzzo.DO.DataAnnotations.vsmdi
 		TraceAndTestImpact.testsettings = TraceAndTestImpact.testsettings
 	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mariuzzo.DO.Validator", "Mariuzzo.DO.Validator\Mariuzzo.DO.Validator.csproj", "{C4796665-909F-410E-8857-42D68F0DD57D}"
 EndProject
 Global
 	GlobalSection(TestCaseManagementSettings) = postSolution
@@ -29,6 +31,10 @@ Global
 		{94A1DB79-EDF1-4A8E-90F1-CAD0BDB30E03}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{94A1DB79-EDF1-4A8E-90F1-CAD0BDB30E03}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{94A1DB79-EDF1-4A8E-90F1-CAD0BDB30E03}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C4796665-909F-410E-8857-42D68F0DD57D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C4796665-909F-410E-8857-42D68F0DD57D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C4796665-909F-410E-8857-42D68F0DD57D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C4796665-909F-410E-8857-42D68F0DD57D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Mariuzzo.DO.DataAnnotations/CedulaAttribute.cs
+++ b/Mariuzzo.DO.DataAnnotations/CedulaAttribute.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.ComponentModel.DataAnnotations;
 using System.Text.RegularExpressions;
+using Mariuzzo.DO.Validator;
 
 namespace Mariuzzo.DO.DataAnnotations
 {
@@ -10,6 +11,7 @@ namespace Mariuzzo.DO.DataAnnotations
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false)]
     public sealed class CedulaAttribute : ValidationAttribute
     {
+        private readonly IValidator _cedulaValidator = new CedulaValidator();
         /// <summary>
         /// Determines if a string value is a valid Cédula.
         /// </summary>
@@ -17,30 +19,7 @@ namespace Mariuzzo.DO.DataAnnotations
         /// <returns><code>true</code> if the string value is a valid Cédula, otherwise <code>false</code>.</returns>
         public override bool IsValid(object value)
         {
-            var str = value as String;
-            if (String.IsNullOrEmpty(str))
-            {
-                return true;
-            }
-
-            Regex regex = new Regex(@"(\d{3}\-\d{7}\-\d{1})|(\d{11})");
-            if (regex.Matches(str).Count == 0)
-            {
-                return false;
-            }
-
-            str = Regex.Replace(str, @"[^\d]", String.Empty);
-
-            // Do check digit.
-            int sum = 0;
-            for (int i = 0; i < 10; ++i)
-            {
-                int n = ((i + 1) % 2 != 0 ? 1 : 2) * int.Parse(str.Substring(i, 1));
-                sum += (n <= 9 ? n : n % 10 + 1);
-            }
-            int dig = ((10 - sum % 10) % 10);
-
-            return dig.Equals(int.Parse(str.Substring(10, 1)));
+            return _cedulaValidator.IsValid(value);
         }
     }
 }

--- a/Mariuzzo.DO.Validator/CedulaValidator.cs
+++ b/Mariuzzo.DO.Validator/CedulaValidator.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Text.RegularExpressions;
+
+namespace Mariuzzo.DO.Validator
+{
+    public class CedulaValidator: IValidator
+    {
+        public bool IsValid(object value)
+        {
+            var str = value as String;
+            if (String.IsNullOrEmpty(str))
+            {
+                return true;
+            }
+
+            Regex regex = new Regex(@"(\d{3}\-\d{7}\-\d{1})|(\d{11})");
+            if (regex.Matches(str).Count == 0)
+            {
+                return false;
+            }
+
+            str = Regex.Replace(str, @"[^\d]", String.Empty);
+
+            // Do check digit.
+            int sum = 0;
+            for (int i = 0; i < 10; ++i)
+            {
+                int n = ((i + 1) % 2 != 0 ? 1 : 2) * int.Parse(str.Substring(i, 1));
+                sum += (n <= 9 ? n : n % 10 + 1);
+            }
+            int dig = ((10 - sum % 10) % 10);
+
+            return dig.Equals(int.Parse(str.Substring(10, 1)));
+        }
+    }
+}

--- a/Mariuzzo.DO.Validator/IValidator.cs
+++ b/Mariuzzo.DO.Validator/IValidator.cs
@@ -1,0 +1,7 @@
+﻿namespace Mariuzzo.DO.Validator
+{
+    public interface IValidator
+    {
+        bool IsValid(object value);
+    }
+}

--- a/Mariuzzo.DO.Validator/Mariuzzo.DO.Validator.csproj
+++ b/Mariuzzo.DO.Validator/Mariuzzo.DO.Validator.csproj
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>8.0.30703</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>{EA62A23F-540A-4A08-BF65-2B0E7D9571E6}</ProjectGuid>
+    <ProjectGuid>{C4796665-909F-410E-8857-42D68F0DD57D}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Mariuzzo.DO.DataAnnotations</RootNamespace>
-    <AssemblyName>Mariuzzo.DO.DataAnnotations</AssemblyName>
+    <RootNamespace>Mariuzzo.DO.Validator</RootNamespace>
+    <AssemblyName>Mariuzzo.DO.Validator</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -32,20 +32,17 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="BbPinAttribute.cs" />
-    <Compile Include="CedulaAttribute.cs" />
-    <Compile Include="MSISDNAttribute.cs" />
+    <Compile Include="CedulaValidator.cs" />
+    <Compile Include="IValidator.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\Mariuzzo.DO.Validator\Mariuzzo.DO.Validator.csproj">
-      <Project>{c4796665-909f-410e-8857-42d68f0dd57d}</Project>
-      <Name>Mariuzzo.DO.Validator</Name>
-    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Mariuzzo.DO.Validator/Properties/AssemblyInfo.cs
+++ b/Mariuzzo.DO.Validator/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Mariuzzo.DO.Validator")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Mariuzzo.DO.Validator")]
+[assembly: AssemblyCopyright("Copyright ©  2013")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("04b5fd66-110c-42de-acac-dafa3a3713bb")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]


### PR DESCRIPTION
- Cedula Validation is now general purpose and can be used outside of
  the context of Data Annotations.
  - Introduced Marriuzo.DO.Validator Assembly
