### PR TITLE
Adding Cedulas Exceptions

### DIFF
--- a/Mariuzzo.DO.DataAnnotations/CedulaAttribute.cs
+++ b/Mariuzzo.DO.DataAnnotations/CedulaAttribute.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.ComponentModel.DataAnnotations;
-using System.Linq;
 using Mariuzzo.DO.Validator;
 
 namespace Mariuzzo.DO.DataAnnotations
@@ -13,10 +12,7 @@ namespace Mariuzzo.DO.DataAnnotations
     {
         
         private readonly IValidator _cedulaValidator = new CedulaValidator();
-        /// <summary>
-        /// Verify some exceptions of valid Cédula that don't follow the Luhn Algorithm
-        /// </summary>
-        public bool IgnoreExceptions = true;
+     
         /// <summary>
         /// Determines if a string value is a valid Cédula.
         /// </summary>
@@ -24,69 +20,8 @@ namespace Mariuzzo.DO.DataAnnotations
         /// <returns><code>true</code> if the string value is a valid Cédula, otherwise <code>false</code>.</returns>
         public override bool IsValid(object value)
         {
-            var str = value as String;
-            return String.IsNullOrEmpty(str) || (!IgnoreExceptions && _validExceptions.Contains(str)) || _cedulaValidator.IsValid(value);
+            return _cedulaValidator.IsValid(value);
         }
-        #region Cédulas that do not fill the criteria of the algorithm
-        private readonly string[] _validExceptions =
-        {
-            "03121982479",
-            "40200401324",
-            "40200700675",
-            "01400074875",
-            "01400000282",
-            "01200004166",
-            "00800106971",
-            "00500146023",
-            "03600005006",
-            "00200123640",
-            "00200066461",
-            "00111685651",
-            "00109802472",
-            "00114532330",
-            "00414198021",
-            "02500017580",
-            "02800004558",
-            "03200066940",
-            "03103749672",
-            "90001200901",
-            "03200033116",
-            "03300222958",
-            "09700061422",
-            "03800032522",
-            "03900192284",
-            "00301200901",
-            "04700160012",
-            "04400030228",
-            "03401548588",
-            "04600176999",
-            "04700382339",
-            "04700502946",
-            "04900026260",
-            "05300049899",
-            "05900072869",
-            "07100144181",
-            "07600106353",
-            "07700009346",
-            "00100759932",
-            "00103098181",
-            "00211870608",
-            "10000063683",
-            "00200409772",
-            "00108436337",
-            "00105278289",
-            "00105606543",
-            "00103022479",
-            "00114272360",
-            "12345678912",
-            "00121581800",
-            "00119161853",
-            "00121581750",
-            "10621581792",
-            "09421581768",
-            "22321581834",
-            "22721581818"
-        };
-        #endregion
+    
     }
 }

--- a/Mariuzzo.DO.DataAnnotations/CedulaAttribute.cs
+++ b/Mariuzzo.DO.DataAnnotations/CedulaAttribute.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.ComponentModel.DataAnnotations;
-using System.Text.RegularExpressions;
+using System.Linq;
 using Mariuzzo.DO.Validator;
 
 namespace Mariuzzo.DO.DataAnnotations
@@ -13,7 +13,10 @@ namespace Mariuzzo.DO.DataAnnotations
     {
         
         private readonly IValidator _cedulaValidator = new CedulaValidator();
-
+        /// <summary>
+        /// Verify some exceptions of valid Cédula that don't follow the Luhn Algorithm
+        /// </summary>
+        public bool IgnoreExceptions = true;
         /// <summary>
         /// Determines if a string value is a valid Cédula.
         /// </summary>
@@ -21,7 +24,69 @@ namespace Mariuzzo.DO.DataAnnotations
         /// <returns><code>true</code> if the string value is a valid Cédula, otherwise <code>false</code>.</returns>
         public override bool IsValid(object value)
         {
-            return _cedulaValidator.IsValid(value);
+            var str = value as String;
+            return String.IsNullOrEmpty(str) || (!IgnoreExceptions && _validExceptions.Contains(str)) || _cedulaValidator.IsValid(value);
         }
+        #region Cédulas that do not fill the criteria of the algorithm
+        private readonly string[] _validExceptions =
+        {
+            "03121982479",
+            "40200401324",
+            "40200700675",
+            "01400074875",
+            "01400000282",
+            "01200004166",
+            "00800106971",
+            "00500146023",
+            "03600005006",
+            "00200123640",
+            "00200066461",
+            "00111685651",
+            "00109802472",
+            "00114532330",
+            "00414198021",
+            "02500017580",
+            "02800004558",
+            "03200066940",
+            "03103749672",
+            "90001200901",
+            "03200033116",
+            "03300222958",
+            "09700061422",
+            "03800032522",
+            "03900192284",
+            "00301200901",
+            "04700160012",
+            "04400030228",
+            "03401548588",
+            "04600176999",
+            "04700382339",
+            "04700502946",
+            "04900026260",
+            "05300049899",
+            "05900072869",
+            "07100144181",
+            "07600106353",
+            "07700009346",
+            "00100759932",
+            "00103098181",
+            "00211870608",
+            "10000063683",
+            "00200409772",
+            "00108436337",
+            "00105278289",
+            "00105606543",
+            "00103022479",
+            "00114272360",
+            "12345678912",
+            "00121581800",
+            "00119161853",
+            "00121581750",
+            "10621581792",
+            "09421581768",
+            "22321581834",
+            "22721581818"
+        };
+        #endregion
     }
 }

--- a/Mariuzzo.DO.Validator/CedulaValidator.cs
+++ b/Mariuzzo.DO.Validator/CedulaValidator.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Text.RegularExpressions;
 
 namespace Mariuzzo.DO.Validator
@@ -8,7 +9,7 @@ namespace Mariuzzo.DO.Validator
         public bool IsValid(object value)
         {
             var str = value as String;
-            if (String.IsNullOrEmpty(str))
+            if (String.IsNullOrEmpty(str) || ValidExceptions.Contains(str))
             {
                 return true;
             }
@@ -37,5 +38,67 @@ namespace Mariuzzo.DO.Validator
 
             return dig == (int)Char.GetNumericValue(str[10]);
         }
+
+        #region Cédulas that do not fill the criteria of the algorithm
+        public readonly static string[] ValidExceptions =
+        {
+            "03121982479",
+            "40200401324",
+            "40200700675",
+            "01400074875",
+            "01400000282",
+            "01200004166",
+            "00800106971",
+            "00500146023",
+            "03600005006",
+            "00200123640",
+            "00200066461",
+            "00111685651",
+            "00109802472",
+            "00114532330",
+            "00414198021",
+            "02500017580",
+            "02800004558",
+            "03200066940",
+            "03103749672",
+            "90001200901",
+            "03200033116",
+            "03300222958",
+            "09700061422",
+            "03800032522",
+            "03900192284",
+            "00301200901",
+            "04700160012",
+            "04400030228",
+            "03401548588",
+            "04600176999",
+            "04700382339",
+            "04700502946",
+            "04900026260",
+            "05300049899",
+            "05900072869",
+            "07100144181",
+            "07600106353",
+            "07700009346",
+            "00100759932",
+            "00103098181",
+            "00211870608",
+            "10000063683",
+            "00200409772",
+            "00108436337",
+            "00105278289",
+            "00105606543",
+            "00103022479",
+            "00114272360",
+            "12345678912",
+            "00121581800",
+            "00119161853",
+            "00121581750",
+            "10621581792",
+            "09421581768",
+            "22321581834",
+            "22721581818"
+        };
+        #endregion
     }
 }

--- a/Mariuzzo.Do.DataAnnotations.Test/CedulaAttributeTest.cs
+++ b/Mariuzzo.Do.DataAnnotations.Test/CedulaAttributeTest.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using Mariuzzo.DO.DataAnnotations;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -29,5 +31,78 @@ namespace Mariuzzo.Do.DataAnnotations.Test
             Assert.IsFalse(attr.IsValid("\n"));
             Assert.IsFalse(attr.IsValid("\n \t"));
         }
+        [TestMethod]
+        public void TestValidCedulasExceptionsShouldReturnValidIfIgnoreExceptionsIsFalse()
+        {
+            var attr = new CedulaAttribute { IgnoreExceptions = false };
+            _validExceptions.ForEach(c => Assert.IsTrue(attr.IsValid(c)));
+        }
+        [TestMethod]
+        public void TestInvalidCedulaWhenIgnoreExceptionsIsFalse()
+        {
+            var attr = new CedulaAttribute();
+            _validExceptions.ForEach(c => Assert.IsFalse(attr.IsValid(c)));
+        }
+        #region Cédulas that do not fill the criteria of the algorithm
+        private readonly List<string> _validExceptions = new List<string>()
+        {
+            "03121982479",
+            "40200401324",
+            "40200700675",
+            "01400074875",
+            "01400000282",
+            "01200004166",
+            "00800106971",
+            "00500146023",
+            "03600005006",
+            "00200123640",
+            "00200066461",
+            "00111685651",
+            "00109802472",
+            "00114532330",
+            "00414198021",
+            "02500017580",
+            "02800004558",
+            "03200066940",
+            "03103749672",
+            "90001200901",
+            "03200033116",
+            "03300222958",
+            "09700061422",
+            "03800032522",
+            "03900192284",
+            "00301200901",
+            "04700160012",
+            "04400030228",
+            "03401548588",
+            "04600176999",
+            "04700382339",
+            "04700502946",
+            "04900026260",
+            "05300049899",
+            "05900072869",
+            "07100144181",
+            "07600106353",
+            "07700009346",
+            "00100759932",
+            "00103098181",
+            "00211870608",
+            "10000063683",
+            "00200409772",
+            "00108436337",
+            "00105278289",
+            "00105606543",
+            "00103022479",
+            "00114272360",
+            "12345678912",
+            "00121581800",
+            "00119161853",
+            "00121581750",
+            "10621581792",
+            "09421581768",
+            "22321581834",
+            "22721581818"
+        };
+        #endregion
     }
 }

--- a/Mariuzzo.Do.DataAnnotations.Test/CedulaAttributeTest.cs
+++ b/Mariuzzo.Do.DataAnnotations.Test/CedulaAttributeTest.cs
@@ -1,7 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using Mariuzzo.DO.DataAnnotations;
+using Mariuzzo.DO.Validator;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Mariuzzo.Do.DataAnnotations.Test
@@ -31,78 +31,13 @@ namespace Mariuzzo.Do.DataAnnotations.Test
             Assert.IsFalse(attr.IsValid("\n"));
             Assert.IsFalse(attr.IsValid("\n \t"));
         }
-        [TestMethod]
-        public void TestValidCedulasExceptionsShouldReturnValidIfIgnoreExceptionsIsFalse()
-        {
-            var attr = new CedulaAttribute { IgnoreExceptions = false };
-            _validExceptions.ForEach(c => Assert.IsTrue(attr.IsValid(c)));
-        }
+
         [TestMethod]
         public void TestInvalidCedulaWhenIgnoreExceptionsIsFalse()
         {
             var attr = new CedulaAttribute();
-            _validExceptions.ForEach(c => Assert.IsFalse(attr.IsValid(c)));
+            var cedulasExceptions = CedulaValidator.ValidExceptions;
+            cedulasExceptions.ToList().ForEach(c => Assert.IsTrue(attr.IsValid(c)));
         }
-        #region Cédulas that do not fill the criteria of the algorithm
-        private readonly List<string> _validExceptions = new List<string>()
-        {
-            "03121982479",
-            "40200401324",
-            "40200700675",
-            "01400074875",
-            "01400000282",
-            "01200004166",
-            "00800106971",
-            "00500146023",
-            "03600005006",
-            "00200123640",
-            "00200066461",
-            "00111685651",
-            "00109802472",
-            "00114532330",
-            "00414198021",
-            "02500017580",
-            "02800004558",
-            "03200066940",
-            "03103749672",
-            "90001200901",
-            "03200033116",
-            "03300222958",
-            "09700061422",
-            "03800032522",
-            "03900192284",
-            "00301200901",
-            "04700160012",
-            "04400030228",
-            "03401548588",
-            "04600176999",
-            "04700382339",
-            "04700502946",
-            "04900026260",
-            "05300049899",
-            "05900072869",
-            "07100144181",
-            "07600106353",
-            "07700009346",
-            "00100759932",
-            "00103098181",
-            "00211870608",
-            "10000063683",
-            "00200409772",
-            "00108436337",
-            "00105278289",
-            "00105606543",
-            "00103022479",
-            "00114272360",
-            "12345678912",
-            "00121581800",
-            "00119161853",
-            "00121581750",
-            "10621581792",
-            "09421581768",
-            "22321581834",
-            "22721581818"
-        };
-        #endregion
     }
 }

--- a/Mariuzzo.Do.DataAnnotations.Test/CedulaAttributeTest.cs
+++ b/Mariuzzo.Do.DataAnnotations.Test/CedulaAttributeTest.cs
@@ -33,11 +33,11 @@ namespace Mariuzzo.Do.DataAnnotations.Test
         }
 
         [TestMethod]
-        public void TestInvalidCedulaWhenIgnoreExceptionsIsFalse()
+        public void TestShouldBeValidForCedulasExceptions()
         {
             var attr = new CedulaAttribute();
             var cedulasExceptions = CedulaValidator.ValidExceptions;
-            cedulasExceptions.ToList().ForEach(c => Assert.IsTrue(attr.IsValid(c)));
+            Assert.IsFalse(cedulasExceptions.Any(c => !attr.IsValid(c)));
         }
     }
 }

--- a/Mariuzzo.Do.DataAnnotations.Test/Mariuzzo.DO.DataAnnotations.Test.csproj
+++ b/Mariuzzo.Do.DataAnnotations.Test/Mariuzzo.DO.DataAnnotations.Test.csproj
@@ -57,6 +57,10 @@
       <Project>{EA62A23F-540A-4A08-BF65-2B0E7D9571E6}</Project>
       <Name>Mariuzzo.DO.DataAnnotations</Name>
     </ProjectReference>
+    <ProjectReference Include="..\Mariuzzo.DO.Validator\Mariuzzo.DO.Validator.csproj">
+      <Project>{C4796665-909F-410E-8857-42D68F0DD57D}</Project>
+      <Name>Mariuzzo.DO.Validator</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 


### PR DESCRIPTION
This is a work around for the exceptions 
-IgnoresException property allows to check or no, the exceptions.
It can be use like [Cedula(IgnoreExceptions = true)]
It ignores the Exceptions by default [Cedula]
-This resolves #8 