### PR TITLE
Issue #12 - Refactoring

### DIFF
--- a/src/DevelopersDo.DataAnnotations.Test/MSISDNAttributeTest.cs
+++ b/src/DevelopersDo.DataAnnotations.Test/MSISDNAttributeTest.cs
@@ -18,6 +18,20 @@ namespace DevelopersDo.DataAnnotations.Test
         }
 
         [Test]
+        [TestCase("8691234567")]
+        [TestCase("839-123-4567")]
+        [TestCase(null)]
+        [TestCase("")]
+        public void TestValidMSISDNs_WithCustomPrefixes(string msisdn)
+        {
+            var attr = new MSISDNAttribute
+            {
+                Prefixes = new[] { "839", "869" }
+            };
+            attr.IsValid(msisdn).Should().BeTrue();
+        }
+
+        [Test]
         [TestCase("foo")]
         [TestCase("0211234567")]
         [TestCase("021-123-4567")]

--- a/src/DevelopersDo.DataAnnotations/BbPinAttribute.cs
+++ b/src/DevelopersDo.DataAnnotations/BbPinAttribute.cs
@@ -18,15 +18,12 @@ namespace DevelopersDo.DataAnnotations
         public override bool IsValid(object value)
         {
             var str = value as string;
+
             if (String.IsNullOrEmpty(str))
-            {
                 return true;
-            }
 
             if (str.Length != 8)
-            {
                 return false;
-            }
 
             uint bbpin;
             return UInt32.TryParse(str, NumberStyles.HexNumber, null, out bbpin);

--- a/src/DevelopersDo.DataAnnotations/BbPinAttribute.cs
+++ b/src/DevelopersDo.DataAnnotations/BbPinAttribute.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.ComponentModel.DataAnnotations;
 using System.Globalization;
+using DevelopersDo.Validator;
 
 namespace DevelopersDo.DataAnnotations
 {
@@ -10,6 +11,11 @@ namespace DevelopersDo.DataAnnotations
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false)]
     public sealed class BbPinAttribute : ValidationAttribute
     {
+        private readonly IValidator _validator;
+        public BbPinAttribute()
+        {
+            _validator = new BbPinValidator();
+        }
         /// <summary>
         /// Determine if a string value is a valid BlackBerry PIN number.
         /// </summary>
@@ -17,16 +23,7 @@ namespace DevelopersDo.DataAnnotations
         /// <returns><code>true</code> if the string value is a valid BlackBerry PIN number, otherwise <code>false</code>.</returns>
         public override bool IsValid(object value)
         {
-            var str = value as string;
-
-            if (String.IsNullOrEmpty(str))
-                return true;
-
-            if (str.Length != 8)
-                return false;
-
-            uint bbpin;
-            return UInt32.TryParse(str, NumberStyles.HexNumber, null, out bbpin);
+            return _validator.IsValid(value);
         }
     }
 }

--- a/src/DevelopersDo.DataAnnotations/CedulaAttribute.cs
+++ b/src/DevelopersDo.DataAnnotations/CedulaAttribute.cs
@@ -10,8 +10,12 @@ namespace DevelopersDo.DataAnnotations
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false)]
     public sealed class CedulaAttribute : ValidationAttribute
     {
-        
-        private readonly IValidator _cedulaValidator = new CedulaValidator();
+        private readonly IValidator _cedulaValidator;
+
+        public CedulaAttribute()
+        {
+            _cedulaValidator = new CedulaValidator();
+        }
      
         /// <summary>
         /// Determines if a string value is a valid Cédula.

--- a/src/DevelopersDo.DataAnnotations/MSISDNAttribute.cs
+++ b/src/DevelopersDo.DataAnnotations/MSISDNAttribute.cs
@@ -11,7 +11,8 @@ namespace DevelopersDo.DataAnnotations
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false)]
     public sealed class MSISDNAttribute : ValidationAttribute
     {
-        private readonly String[] _defaultPrefixes = { "809", "829", "849" };
+        private static readonly String[] DefaultPrefixes = { "809", "829", "849" };
+        private static readonly Regex MSISDNRegex = new Regex(@"(\d{3}\-\d{3}\-\d{4})|(\d{10})", RegexOptions.Compiled);
 
         public String[] Prefixes { get; set; }
 
@@ -23,19 +24,15 @@ namespace DevelopersDo.DataAnnotations
         public override bool IsValid(object value)
         {
             var str = value as String;
+            
             if (String.IsNullOrEmpty(str))
-            {
                 return true;
-            }
 
-            Regex regex = new Regex(@"(\d{3}\-\d{3}\-\d{4})|(\d{10})");
-            if (regex.Matches(str).Count == 0)
-            {
+            if (MSISDNRegex.Matches(str).Count == 0)
                 return false;
-            }
 
             str = new string(str.Where(Char.IsDigit).ToArray());
-            return (Prefixes ?? _defaultPrefixes).Any(p => str.StartsWith(p));
+            return (Prefixes ?? DefaultPrefixes).Any(p => str.StartsWith(p));
         }
     }
 }

--- a/src/DevelopersDo.DataAnnotations/RNCAttribute.cs
+++ b/src/DevelopersDo.DataAnnotations/RNCAttribute.cs
@@ -10,8 +10,12 @@ namespace DevelopersDo.DataAnnotations
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false)]
     public sealed class RNCAttribute : ValidationAttribute
     {
-        private readonly IValidator _rncValidator = new RNCValidator();
-
+        private readonly IValidator _rncValidator;
+        public RNCAttribute()
+        {
+            _rncValidator = new RNCValidator();
+        }
+        
         /// <summary>
         /// Determines if a string value is a valid RNC.
         /// </summary>

--- a/src/DevelopersDo.Validator/BbPinValidator.cs
+++ b/src/DevelopersDo.Validator/BbPinValidator.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Globalization;
+
+namespace DevelopersDo.Validator
+{
+    public class BbPinValidator : IValidator
+    {
+        public bool IsValid(object value)
+        {
+            var str = value as String;
+
+            if (String.IsNullOrEmpty(str))
+                return true;
+
+            if (str.Length != 8)
+                return false;
+
+            uint bbpin;
+            return UInt32.TryParse(str, NumberStyles.HexNumber, null, out bbpin);
+        }
+    }
+}

--- a/src/DevelopersDo.Validator/CedulaValidator.cs
+++ b/src/DevelopersDo.Validator/CedulaValidator.cs
@@ -6,35 +6,34 @@ namespace DevelopersDo.Validator
 {
     public class CedulaValidator: IValidator
     {
+        private static readonly Regex CedulaRegex = new Regex(@"^[0-9]{3}-?[0-9]{7}-?[0-9]{1}$", RegexOptions.Compiled);
+        private static readonly Regex NonDigitRegex = new Regex(@"[^\d]", RegexOptions.Compiled);
+
         public bool IsValid(object value)
         {
             var str = value as String;
+
             if (String.IsNullOrEmpty(str) || ValidExceptions.Contains(str))
-            {
                 return true;
-            }
 
-            var regex = new Regex(@"^[0-9]{3}-?[0-9]{7}-?[0-9]{1}$");
-            if (!regex.IsMatch(str))
-            {
+            if (!CedulaRegex.IsMatch(str))
                 return false;
-            }
 
-            str = Regex.Replace(str, @"[^\d]", String.Empty);
+            str = NonDigitRegex.Replace(str, String.Empty);
 
             // Do check digit.
             return CheckDigit(str);
         }
 
-        private bool CheckDigit(string str)
+        private static bool CheckDigit(string str)
         {
-            int sum = 0;
-            for (int i = 0; i < 10; ++i)
+            var sum = 0;
+            for (var i = 0; i < 10; ++i)
             {
-                int n = ((i + 1) % 2 != 0 ? 1 : 2) * (int)Char.GetNumericValue(str[i]);
+                var n = ((i + 1) % 2 != 0 ? 1 : 2) * (int)Char.GetNumericValue(str[i]);
                 sum += (n <= 9 ? n : n % 10 + 1);
             }
-            int dig = ((10 - sum % 10) % 10);
+            var dig = ((10 - sum % 10) % 10);
 
             return dig == (int)Char.GetNumericValue(str[10]);
         }

--- a/src/DevelopersDo.Validator/DevelopersDo.Validator.csproj
+++ b/src/DevelopersDo.Validator/DevelopersDo.Validator.csproj
@@ -40,6 +40,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="BbPinValidator.cs" />
     <Compile Include="CedulaValidator.cs" />
     <Compile Include="IValidator.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/DevelopersDo.Validator/RNCValidator.cs
+++ b/src/DevelopersDo.Validator/RNCValidator.cs
@@ -5,43 +5,48 @@ namespace DevelopersDo.Validator
 {
     public class RNCValidator : IValidator
     {
+        private static readonly Regex RncRegex = new Regex(@"^(1|4|5)-?[0-9]{2}-?[0-9]{5}-?[0-9]{1}$", RegexOptions.Compiled);
+        private static readonly Regex NonDigitRegex = new Regex(@"[^\d]", RegexOptions.Compiled);
+        private static readonly int[] BaseDigits = { 7, 9, 8, 6, 5, 4, 3, 2 };
+
         public bool IsValid(object value)
         {
             var str = value as String;
+            
             if (String.IsNullOrEmpty(str))
-            {
                 return true;
-            }
 
-            var regex = new Regex(@"^(1|4|5)-?[0-9]{2}-?[0-9]{5}-?[0-9]{1}$");
-            if (!regex.IsMatch(str))
-            {
+            if (!RncRegex.IsMatch(str))
                 return false;
-            }
 
-            str = Regex.Replace(str, @"[^\d]", String.Empty);
+            str = NonDigitRegex.Replace(str, String.Empty);
 
-            // Do check digit.
+            // Do check digit algorithm.
             return CheckDigit(str);
         }
 
-        private bool CheckDigit(string str)
+        private static bool CheckDigit(string str)
         {
-            var baseDigs = new int[] { 7, 9, 8, 6, 5, 4, 3, 2 };
-            int result = 0;
-            int digit = 0;
+            var result = 0;
+            int digit;
 
-            for (int i = 0; i < 8; i++)
-                result += baseDigs[i] * (int)Char.GetNumericValue(str[i]);
+            for (var i = 0; i < 8; i++)
+                result += BaseDigits[i] * (int)Char.GetNumericValue(str[i]);
 
             result = result % 11;
 
-            if (result == 0)
-                digit = 2;
-            else if (result == 1)
-                digit = 1;
-            else
-                digit = 11 - result;
+            switch (result)
+            {
+                case 0:
+                    digit = 2;
+                    break;
+                case 1:
+                    digit = 1;
+                    break;
+                default:
+                    digit = 11 - result;
+                    break;
+            }
 
             return digit == (int)Char.GetNumericValue(str[8]);
         }


### PR DESCRIPTION
- Moved Regular Expressions to static readonly fields with compiled option
- Added BbPinValidator class
- Made validator fields use Poor Man's DI instead of getting an instance
  directly in the private field declaration.
- Added unit tests for MSISDN attribute with user-defined prefixes
- Made formatting changes

_PENDING_ adding a validator class to the MSISDN attribute when possible. Can't really do it smoothly with the current IValidator interface, since it doesn't admit parameters other than the object being validated.
